### PR TITLE
Fix: Use lazy loading to resolve circular import

### DIFF
--- a/signal_protocol/__init__.py
+++ b/signal_protocol/__init__.py
@@ -1,24 +1,9 @@
 # Import the compiled Rust extension module directly
 from . import _signal_protocol
+import sys
 
-# Re-export all submodules
-address = _signal_protocol.address
-curve = _signal_protocol.curve
-error = _signal_protocol.error
-fingerprint = _signal_protocol.fingerprint
-group_cipher = _signal_protocol.group_cipher
-identity_key = _signal_protocol.identity_key
-protocol = _signal_protocol.protocol
-ratchet = _signal_protocol.ratchet
-sealed_sender = _signal_protocol.sealed_sender
-sender_keys = _signal_protocol.sender_keys
-session_cipher = _signal_protocol.session_cipher
-session = _signal_protocol.session
-state = _signal_protocol.state
-storage = _signal_protocol.storage
-
-# Export everything
-__all__ = [
+# List of all submodules/attributes to be lazily loaded from _signal_protocol
+_LAZY_LOAD_ATTRIBUTES = [
     'address',
     'curve',
     'error',
@@ -34,3 +19,34 @@ __all__ = [
     'state',
     'storage',
 ]
+
+__all__ = _LAZY_LOAD_ATTRIBUTES
+
+def __getattr__(name: str):
+    if name in _LAZY_LOAD_ATTRIBUTES:
+        # Get the attribute from the Rust extension module
+        module = getattr(_signal_protocol, name)
+        # Cache it on the current module (signal_protocol) for future accesses
+        setattr(sys.modules[__name__], name, module)
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+# To ensure IDEs and static analyzers can still "see" the attributes,
+# especially if they don't execute __getattr__ during analysis.
+# This block is optional and might not be necessary depending on tooling.
+if typing.TYPE_CHECKING:
+    from ._signal_protocol import address
+    from ._signal_protocol import curve
+    from ._signal_protocol import error
+    from ._signal_protocol import fingerprint
+    from ._signal_protocol import group_cipher
+    from ._signal_protocol import identity_key
+    from ._signal_protocol import protocol
+    from ._signal_protocol import ratchet
+    from ._signal_protocol import sealed_sender
+    from ._signal_protocol import sender_keys
+    from ._signal_protocol import session_cipher
+    from ._signal_protocol import session
+    from ._signal_protocol import state
+    from ._signal_protocol import storage
+    import typing


### PR DESCRIPTION
Implement lazy loading in `signal_protocol/__init__.py` to resolve a circular import issue that occurred when Python classes subclassed Rust-defined Pyo3 classes (e.g., `PersistentStorageBase`).

The circular import was likely triggered during the initialization of the `_signal_protocol` Rust extension module and the simultaneous definition of Python subclasses in test files, particularly in CI environments.

Lazy loading defers the resolution of submodules until they are explicitly accessed, breaking the import cycle.